### PR TITLE
vim-lsp: Add undercurl decorations to diagnostics

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -773,6 +773,10 @@ hi! link LspWarningText GruvboxYellowSign
 hi! link LspInformationText GruvboxBlueSign
 hi! link LspHintText GruvboxBlueSign
 
+call s:HL('LspErrorHighlight', s:none, s:none, s:undercurl, s:red)
+call s:HL('LspWarningHighlight', s:none, s:none, s:undercurl, s:orange)
+call s:HL('LspInfoHighlight', s:none, s:none, s:undercurl, s:yellow)
+call s:HL('LspHintHighlight', s:none, s:none, s:undercurl, s:blue)
 call s:HL('lspReference', s:none, s:none, s:inverse . s:italic, s:none)
 
 " }}}


### PR DESCRIPTION
Sending these to you to avoid opening a PR to morhetz that depends on another one (morhetz/gruvbox#331).

The fallback values were taken from the settings for coc.nvim.